### PR TITLE
Enabled safer JSch cipher suite for SCP / SSH

### DIFF
--- a/src/org/wavescale/sourcesync/synchronizer/SCPFileSynchronizer.java
+++ b/src/org/wavescale/sourcesync/synchronizer/SCPFileSynchronizer.java
@@ -42,6 +42,7 @@ public class SCPFileSynchronizer extends FileSynchronizer {
                         this.getConnectionInfo().getPort());
                 this.session.setPassword(this.getConnectionInfo().getUserPassword());
                 this.session.setConfig("StrictHostKeyChecking", "no");
+				this.session.setConfig("kex", "diffie-hellman-group1-sha1,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256");
                 this.session.connect();
                 this.setConnected(true);
                 return true;


### PR DESCRIPTION
Hi, the current JSch implementation only supports SSH ciphers out of the box that are detemined insecure and therefore not supported by modern linux distributions by default. I faced the issue in particular while trying to sync files via SCP to a vanilla Debian 8. The response from the failure looks like the follow:

```
com.jcraft.jsch.JSchException: Algorithm negotiation fail
```

Luckily the JSch version you use has the support for a secure cipher built in, but not enabled by default. [See here](http://sourceforge.net/p/jsch/mailman/message/32975616/)

This is done by the attached Pull Request. Afterwards the SCP connection should work with more recent *nix systems again out of the box.

Brgds